### PR TITLE
[Feat] 친구 페이지 API 연동

### DIFF
--- a/src/api/friends.js
+++ b/src/api/friends.js
@@ -21,7 +21,16 @@ export const findFriendshipByFriendId = async (friendUserId) => {
   return list.find((f) => Number(f.friendUserId) === Number(friendUserId)) || null;
 };
 
-export const getFriendScraps = async ( friendUserId ) => {
-  const res = await api.get(`/friend/${friendUserId}/scraps`);
-  return res.data;
+// export const getFriendScraps = async ( friendUserId ) => {
+//   const res = await api.get(`/friend/${friendUserId}/scraps`);
+//   return res.data;
+// };
+
+export const getFriendScraps = async (friendUserId) => {
+  try {
+    const res = await api.get(`/friend/${friendUserId}/scraps`);
+    return res.data;
+  } catch (err) {
+    console.error("❌ API 호출 실패", err.response?.status, err.response?.data);
+  }
 };

--- a/src/api/scraps.js
+++ b/src/api/scraps.js
@@ -7,6 +7,11 @@ export const getScraps = async () => {
   return res.data;
 };
 
+export const getCategoryScraps = async (categoryId) =>  {
+  const res = await api.get(`/categories/${categoryId}/scraps`);
+  return res.data;
+};
+
 export const getScrapsReminder = async () => {
   const res = await api.get("/scraps/reminders");
   return res.data;

--- a/src/components/LinkMind.jsx
+++ b/src/components/LinkMind.jsx
@@ -46,14 +46,14 @@ const ListWrapper = styled.div`
 `;
 
 const ListItem = styled.div`
-  width: 250px;
+  width: 200px;
   display: flex;
   flex-direction: column;
   gap: 5px;
 `;
 
 const ItemTitle = styled.div`
-  font-size: 22px;
+  font-size: 20px;
   font-weight: 400;
   font-family: Pretendard, sans-serif;
   color: black;
@@ -61,7 +61,7 @@ const ItemTitle = styled.div`
 `;
 
 const ItemSubtitle = styled.div`
-  font-size: 20px;
+  font-size: 18px;
   font-weight: 400;
   font-family: Pretendard, sans-serif;
   color: #767676;

--- a/src/components/SortBar.jsx
+++ b/src/components/SortBar.jsx
@@ -64,6 +64,7 @@ const DropdownWrapper = styled.div`
 
 const SortBar = ({ selectedCategory, onCategoryChange }) => {
   const [openDropdown, setOpenDropdown] = useState(null);
+  const [sortOrder, setSortOrder] = useState("latest");
 
   const handleClick = (btnId) => {
     setOpenDropdown(openDropdown === btnId ? null : btnId); // 토글만
@@ -93,7 +94,13 @@ const SortBar = ({ selectedCategory, onCategoryChange }) => {
         </Label>
         {openDropdown === 2 && (
           <DropdownWrapper style={{ left: "-35px" }}>
-            <SortBarBox2 />
+            <SortBarBox2
+              sortOrder={sortOrder}
+              onSortChange={(order) => {
+                setSortOrder(order);   // 정렬 상태 변경
+                setOpenDropdown(null); // 드롭다운 닫기
+              }}
+            />
           </DropdownWrapper>
         )}
       </ButtonGroup>

--- a/src/components/SortBarBox1.jsx
+++ b/src/components/SortBarBox1.jsx
@@ -68,7 +68,6 @@ export const SortBarBox1 = ({ selectedCategory, onCategoryChange }) => {
       loadCategories();
     }, []);
 
-  
     
   return (
     <div>
@@ -81,10 +80,12 @@ export const SortBarBox1 = ({ selectedCategory, onCategoryChange }) => {
               style={{
                 fontWeight: selectedCategory === cat.categoryId ? 'bold' : 'normal',
               }}
-              onClick={() => onCategoryChange(cat.categoryId)} 
-            >
-              {cat.categoryName}
-            </BoxItem>
+                onClick={() => {
+                  onCategoryChange(cat.categoryId);
+                }}
+              >
+                {cat.categoryName}
+              </BoxItem>
             <BoxDivider />
           </div>
         ))}
@@ -106,7 +107,7 @@ export const SortBarBox1 = ({ selectedCategory, onCategoryChange }) => {
                 onClose={() => setOpenMore(false)}
                 onSave={(value) => {
                   console.log("새 카테고리 저장:", value);
-                  onCategoryChange(cat.categoryId);
+                  onCategoryChange(value);
                   setOpenMore(false);
                 }}
               />

--- a/src/components/SortBarBox2.jsx
+++ b/src/components/SortBarBox2.jsx
@@ -4,28 +4,25 @@ const BoxContainer = styled.div`
   width: 100%;
   height: 100%;
   position: relative;
-  justify-content: center; 
+  justify-content: center;
   align-items: center;
   border-radius: 10px;
 `;
 
 const Box = styled.div`
   width: 129px;
-  height: 100%;
   background: white;
   border-radius: 10px;
   border: 1px solid #909090;
 
   display: flex;
   flex-direction: column;
-  justify-content: flex-start;
 `;
 
 const BoxDivider = styled.div`
-  width: 128px;
+  width: 100%;
   height: 0;
   border-top: 1px solid #909090;
-  top: ${(props) => props.top || 0}px;
 `;
 
 const BoxItem = styled.div`
@@ -35,23 +32,33 @@ const BoxItem = styled.div`
   justify-content: center;
   padding: 8px 0px;
 
-  color: black;
+  color: "black";
+  font-weight:  ${({ $active }) => ($active ? "700" : "400")};
   font-family: "Pretendard", sans-serif;
-  font-weight: 400;
   font-size: 15px;
   line-height: 14px;
   gap: 8px;
+  cursor: pointer;
 `;
 
-export const SortBarBox2 = () => {
+export const SortBarBox2 = ({ sortOrder, onSortChange }) => {
   return (
     <BoxContainer>
       <Box>
-        <BoxItem>최신순</BoxItem>
+        <BoxItem
+          $active={sortOrder === "latest"}
+          onClick={() => onSortChange("latest")}
+        >
+          최신순
+        </BoxItem>
         <BoxDivider />
-        <BoxItem>오래된 순</BoxItem>
-        <BoxDivider />
+        <BoxItem
+          $active={sortOrder === "oldest"}
+          onClick={() => onSortChange("oldest")}
+        >
+          오래된 순
+        </BoxItem>
       </Box>
     </BoxContainer>
   );
-}
+};

--- a/src/pages/FriendList.jsx
+++ b/src/pages/FriendList.jsx
@@ -2,36 +2,40 @@ import styled from "styled-components";
 import { PageHeader } from "../components/PageHeader";
 import FriendListCard from "./friends/FriendListCard";
 
+// 페이지 전체 컨테이너
+const PageContainer = styled.div`
+  padding: 10px;
+  width: 100%;
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+  gap: 15px;
+`;
+
+// 콘텐츠 영역
 const ContentWrapper = styled.div`
   width: 100%;
-
-  display: flex; 
-  flex-direction: column; 
+  display: flex;
+  flex-direction: column;
   align-items: center;
-  justify-content: center;
-  
-  margin: 10px;
   gap: 20px;
+  margin: 10px 0;
 `;
 
 // 검색 바
 const SearchBar = styled.input`
   width: 100%;
-  max-width: 1300px;
+  max-width: 1200px;
   height: 55px;
   margin: 0 auto;
+  padding: 0 24px;
 
   opacity: 0.5;
   box-shadow: 0px 4px 4px rgba(0, 0, 0, 0.25);
   border-radius: 40px;
   border: 1px solid #b4b1b1;
 
-  display: flex;
-  align-items: center;
-  justify-content: center;
-
-  padding: 0 24px;
-  gap: 15px;
+  font-size: 16px;
 `;
 
 export const FriendList = () => {

--- a/src/pages/friends/FriendCard.jsx
+++ b/src/pages/friends/FriendCard.jsx
@@ -50,7 +50,14 @@ export default function FriendCard({ friend }) {
     <CardWrapper>
       <ProfileContainer>
         <ProfileImage src={profile} alt="친구 프로필" /> 
-        <Username to={`/friends/${friend.friendUserId}`}>
+        <Username 
+          to={`/friends/${friend.friendUserId}`} 
+          state={{ 
+            nickname: friend.friendNickname, 
+            friendUserId: friend.friendUserId,
+            initialFriendshipId: friend.friendshipId
+          }}
+        >
           {friend.friendNickname}
         </Username>
       </ProfileContainer>

--- a/src/pages/friends/FriendInfo.jsx
+++ b/src/pages/friends/FriendInfo.jsx
@@ -2,7 +2,9 @@
 import styled from "styled-components";
 import FriendInfoCard from "./FriendInfoCard";
 import FriendPostListLayout from "./FriendPostListLayout";
-import { useParams } from "react-router-dom";
+import { useParams, useLocation } from "react-router-dom";
+import { useEffect, useState } from "react";
+import { getFriendScraps } from "../../api/friends";
 
 const FriendContentWrapper = styled.div`
   width: 100%;
@@ -15,32 +17,39 @@ const FriendContentWrapper = styled.div`
 
   justify-items: center;
   align-items: center;
-  justify-content: center;
+  justify-content: flex-start;
 `;
 
 export default function FriendInfo() {
-  const { id } = useParams();
+  const location = useLocation();
+  const { nickname, friendUserId, initialFriendshipId } = location.state || {};
 
-  const friendData = {
-    email: "test@example.com",
-    userId: `ID_is_${id}`,
-    profileImg: "/assets/profile.jpg",
-  };
+  // 문제가 되는 코드
+  const id = useParams();
+  const [friendPosts, setFriendPosts] = useState([]);
 
-  const friendPosts = [
-    { id: 1, title: "여름 너무 더운데 우짜나~", description: "내 여름 추구미...", isRescrapped: true },
-    { id: 2, title: "오늘 점심은 칼국수", description: "냉우동보다 좋음", isRescrapped: false },
-    { id: 3, title: "바람이 시원하다", description: "가을 느낌", isRescrapped: true },
-  ];
+  // useEffect(() => {
+  //   const loadFriendPosts = async () => {
+  //     try {
+  //       const data = await getFriendScraps(id); 
+  //       console.log("친구 스크랩 목록:", data);
+  //       setFriendPosts(data);
+  //     } catch (err) {
+  //       console.error("친구 스크랩 불러오기 실패:", err);
+  //     }
+  //   };
+  //   loadFriendPosts();
+  // }, [id]);
 
   return (
     <FriendContentWrapper>
       <FriendInfoCard
-        email={friendData.email}
-        userId={friendData.userId}
-        profileImg={friendData.profileImg}
+        userId={nickname}
+        friendUserId={friendUserId}
+        initialFriendshipId={initialFriendshipId}
       />
       <FriendPostListLayout posts={friendPosts} />
     </FriendContentWrapper>
   );
 }
+

--- a/src/pages/friends/FriendInfoCard.jsx
+++ b/src/pages/friends/FriendInfoCard.jsx
@@ -2,6 +2,7 @@
 import styled from "styled-components";
 import profileImage from "../../assets/profile.jpg";
 import FollowButton from "../../components/FollowButton";
+import { useLocation } from "react-router-dom";
 
 /* ===== 프로필 카드 ===== */
 const ProfileWrapper = styled.div`
@@ -46,18 +47,23 @@ const IdText = styled.div`
   font-weight: 700;
 `;
 
-// 추후에 src 속성 안 profileImage -> profileImg 변경 후 import 삭제
-export default function FriendInfoCard({ email, userId, profileImg }) {
+export default function FriendInfoCard() {
+  const location = useLocation();
+  const { nickname, friendUserId, initialFriendshipId } = location.state || {};
+  
   return (
+    
     <ProfileWrapper>
       <ProfileInfoGroup>
         <ProfileImage src={profileImage} alt="프로필" />
         <ProfileTextGroup>
-          <EmailText>{email}</EmailText>
-          <IdText>{userId}</IdText>
+          <IdText>{nickname}</IdText>
         </ProfileTextGroup>
       </ProfileInfoGroup>
-      <FollowButton />
+      <FollowButton 
+        friendUserId={friendUserId} 
+        initialFriendshipId={initialFriendshipId}  
+      />
     </ProfileWrapper>
   );
 }

--- a/src/pages/friends/FriendListCard.jsx
+++ b/src/pages/friends/FriendListCard.jsx
@@ -5,13 +5,13 @@ import FriendCard from "./FriendCard";
 
 const Container = styled.div`
   width: 100%;
-  max-width: 1300px;
+  max-width: 1200px;
   margin: 0 auto;
   max-height: 500px;
 
   background: #FFE3D7;
   border-radius: 30px;
-  padding: 30px;
+  padding: 20px;
   gap: 20px;
 
   display: grid;

--- a/src/pages/friends/FriendPostListLayout.jsx
+++ b/src/pages/friends/FriendPostListLayout.jsx
@@ -5,7 +5,7 @@ import Pagination from "../../components/Pagination";
 import externalLink from "../../assets/icons/external-link.svg";
 import rescrapPin from "../../assets/icons/pin_fill.svg";
 import { useNavigate } from "react-router-dom";
-import { useState } from "react";
+import { useState, useEffect } from "react";
 
 const FrameWrapper = styled.div`
   width: 100%;
@@ -116,7 +116,30 @@ const ContentItem = ({ title, description, onClick, isRescrapped }) => (
 
 export default function FriendPostListLayout({ posts }) {
   const [activeTab, setActiveTab] = useState("all");
+  const [currentPage, setCurrentPage] = useState(1);
+  const [totalPages, setTotalPages] = useState(1);
+  const pageSize = 4;
   const navigate = useNavigate();
+
+  // const filteredScraps = posts.filter((scrap) => {
+  //   // 1. 즐겨찾기 적용
+  //   if (activeTab === "favorites" && !scrap.favorite) return false;
+
+  //   // 2. 카테고리 적용
+  //   if (selectedCategory && scrap.categoryId !== selectedCategory)
+  //     return false;
+
+  //   return true;
+  // });
+  
+  useEffect(() => {
+    setTotalPages(posts && posts.length > 0 ? Math.ceil(posts.length / pageSize) : 1);
+    setCurrentPage(1); 
+  }, [posts]);
+
+  const pagedScraps = posts && posts.length > 0
+    ? posts.slice((currentPage - 1) * pageSize, currentPage * pageSize)
+    : [];
 
   return (
     <div style={{ display: "flex", flexDirection: "column", width: "100%", gap: "10px" }}>
@@ -127,23 +150,35 @@ export default function FriendPostListLayout({ posts }) {
         </HeaderWrapper>
         <FrameWrapper>
           <InnerWrapper>
-            {posts.map((item) => (
-              <div key={item.id} style={{ width: "100%" }}>
-                <ContentItem
-                  title={item.title}
-                  description={item.description}
-                  isRescrapped={item.isRescrapped} 
-                  onClick={() => navigate(`/post/${item.id}`)}
-                />
-                {item.id !== posts[posts.length - 1].id && <Divider />}
+            {pagedScraps.length > 0 ? (
+              pagedScraps.map((item, index) => (
+                <div key={item.scrapId} style={{ width: "100%" }}>
+                  <ContentItem
+                    title={item.scrapTitle}
+                    description={item.scrapMemo}
+                    isRescrapped={item.isRescrapped} 
+                    onClick={() => navigate(`/post/${item.scrapId}`)}
+                  />
+                  {index !== pagedScraps.length - 1 && <Divider />}
+                </div>
+              ))
+            ) : (
+              <div style={{ color: "#767676", fontSize: "16px" }}>
+                스크랩이 없습니다.
               </div>
-            ))}
+            )}
           </InnerWrapper>
         </FrameWrapper>
       </div>
-      <div style={{ display: "flex", justifyContent: "center" }}>
-        <Pagination currentPage={1} totalPages={5} />
-      </div>
+      {pagedScraps.length > 0 && (
+        <div style={{ display: "flex", justifyContent: "center" }}>
+          <Pagination
+            currentPage={currentPage}
+            totalPages={totalPages}
+            onPageChange={setCurrentPage}
+          />
+        </div>
+      )}
     </div>
   );
 }

--- a/src/pages/postlist/PostlistLayout.jsx
+++ b/src/pages/postlist/PostlistLayout.jsx
@@ -4,7 +4,7 @@ import SortBar from "../../components/SortBar";
 import Pagination from "../../components/Pagination";
 import { useNavigate } from "react-router-dom";
 import { useState, useEffect } from "react";
-import { getScraps } from "../../api/scraps";
+import { getScraps, getCategoryScraps } from "../../api/scraps";
 
 const FrameWrapper = styled.div`
   width: 100%;
@@ -94,10 +94,17 @@ export default function PostlistLayout() {
   useEffect(() => {
     const loadScraps = async () => {
       try {
-        const data = await getScraps({
-          categoryId: selectedCategory,
-          favorite: activeTab === "favorites" ? true : undefined,
-        });
+        let data;
+        console.log(selectedCategory);
+        if (selectedCategory) {
+          data = await getCategoryScraps(selectedCategory, {
+            favorite: activeTab === "favorites" ? true : undefined,
+          });
+        } else {
+          data = await getScraps({
+            favorite: activeTab === "favorites" ? true : undefined,
+          });
+        }
         console.log("스크랩 응답:", data);
 
         setScraps(Array.isArray(data) ? data : []);
@@ -111,12 +118,7 @@ export default function PostlistLayout() {
   }, [selectedCategory, activeTab]);
 
   const filteredScraps = scraps.filter((scrap) => {
-    // 1. 즐겨찾기 적용
     if (activeTab === "favorites" && !scrap.favorite) return false;
-
-    // 2. 카테고리 적용
-    if (selectedCategory && scrap.categoryId !== selectedCategory) return false;
-
     return true;
   });
 
@@ -134,26 +136,28 @@ export default function PostlistLayout() {
           <SortBar
             selectedCategory={selectedCategory}
             onCategoryChange={(categoryId) => {
-              if (selectedCategory === categoryId) {
-                setSelectedCategory(null); // 이미 선택된 카테고리면 해제
-              } else {
-                setSelectedCategory(categoryId);
-              }
+              setSelectedCategory((prev) => (prev === categoryId ? null : categoryId));
             }}
           />
         </HeaderWrapper>
         <FrameWrapper>
           <InnerWrapper>
-            {pagedScraps.map((item, index) => (
-              <div key={item.scrapId} style={{ width: "100%" }}>
-                <ContentItem
-                  title={item.scrapTitle}
-                  description={item.scrapMemo}
-                  onClick={() => navigate(`/post/${item.scrapId}`)}
-                />
-                {index !== pagedScraps.length - 1 && <Divider />}
+            {pagedScraps.length > 0 ? (
+              pagedScraps.map((item, index) => (
+                <div key={item.scrapId} style={{ width: "100%" }}>
+                  <ContentItem
+                    title={item.scrapTitle}
+                    description={item.scrapMemo}
+                    onClick={() => navigate(`/post/${item.scrapId}`)}
+                  />
+                  {index !== pagedScraps.length - 1 && <Divider />}
+                </div>
+              ))
+            ) : (
+              <div style={{ color: "#767676", fontSize: "16px" }}>
+                스크랩이 없습니다.
               </div>
-            ))}
+            )}
           </InnerWrapper>
         </FrameWrapper>
       </div>


### PR DESCRIPTION
## PR 타입

- [x] 기능 추가
- [ ] 기능 삭제
- [x] 버그 수정
- [ ] 의존성 / 환경 변수 / 빌드 관련 코드 업데이트
- [x] 스타일 수정

---

## 주요 변경 사항 및 결과

- 우선 친구 스크랩 목록을 제외한 친구 정보를 모두 반영하였습니다.
- 친구 스크랩 목록은 스크랩이 없어 조회할 수 없음으로 처리하였습니다.
- 세부 스타일 조정하였습니다
- 카테고리 반영 안되는 부분 수정하였습니다.

---

## 논의가 필요한 사항

- [ ] 친구 전체 목록 혹은 스크랩만 갖고 오는 API만 있고 친구 상세 정보 API를 찾는 기능이 없어 이메일을 제외해두었고 프로필 사진은 기본 이미지로 반영하였습니다.
- [ ] profile API를 통해 친구 정보를 가져오는 방법도 시도했지만, 권한 문제로 접근할 수 없었습니다.
- [ ] 오류가 발생하는 친구 스크랩 목록은 우선 스크랩이 없는 상태로 반영해두었습니다. 친구 리스트를 조회했을 때 빈 리스트만 출력해 이렇게 하는 게 최선의 방법 같아서 아래 사진과 같이 구현하였는데 문제가 있다면 꼭 말씀해주세요.
- [ ] 스타일 리팩토링을 시도하였으나, 일이 커질 것 같아 우선 자잘하게 스타일 요소들만 정리했습니다. 혹시 리팩토링 정리하는 방식이 있다면 반영해 정리해두겠습니다. 

---

## 반영 브랜치

main

---

## 스크린샷 (선택)
<img width="1889" height="884" alt="image" src="https://github.com/user-attachments/assets/456d5704-a9ca-4274-b773-6f3cdda20925" />
